### PR TITLE
Clean up explore page by not showing old updates

### DIFF
--- a/src/graphql/resolvers/Query/exploreUpdates.js
+++ b/src/graphql/resolvers/Query/exploreUpdates.js
@@ -1,10 +1,14 @@
 export default (root, args, { session, models }) => {
 	session.authenticationRequired(['exploreUpdates']);
-
+	const twoWeeksAgo = new Date();
+	twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
 	return models.updates.findAll({
 		where: {
 			type: 'public',
-			approval: 'approved'
+			approval: 'approved',
+			createdAt: {
+				[models.Sequelize.Op.gt]: twoWeeksAgo
+			}
 		},
 		order: [['createdAt', 'desc']]
 	});


### PR DESCRIPTION
Currently shows posts newer than *two weeks* old. Probably would want to bring up in the meeting what would be a good expiry time.
