### PR TITLE
added limit and offset to explore updates query

### DIFF
--- a/src/graphql/resolvers/Query/exploreUpdates.js
+++ b/src/graphql/resolvers/Query/exploreUpdates.js
@@ -1,7 +1,9 @@
-export default (root, args, { session, models }) => {
+export default (root, { limit, offset }, { session, models }) => {
 	session.authenticationRequired(['exploreUpdates']);
 
 	return models.updates.findAll({
+		limit,
+		offset,
 		where: {
 			type: 'public',
 			approval: 'approved'

--- a/src/graphql/schema/Query.js
+++ b/src/graphql/schema/Query.js
@@ -48,7 +48,7 @@ export default gql`
 
 		clubFairResponse(orgId: Int!): ClubFairResponse
 
-		exploreUpdates: [Update]
+		exploreUpdates(limit: Int! = 15, offset: Int! = 0): [Update]
 		exploreMeetings: [Meeting]
 
 		upcomingUserMeetings(userId: Int!): [Meeting!]


### PR DESCRIPTION
help prevent the overloading of the explore page by making sure that we paginate the updates