### PR TITLE
Optimize mass sending of emails for meeting notifications

### DIFF
--- a/src/graphql/resolvers/Mutation/alterMeeting.js
+++ b/src/graphql/resolvers/Mutation/alterMeeting.js
@@ -116,23 +116,23 @@ export default async (
 			}
 		});
 
-		for (let i = 0; i < members.length; i++) {
-			const member = members[i];
-
-			await sendEmail({
-				to: member.email,
-				subject: `${org.name} altered a meeting | StuyActivities`,
-				template: 'alterMeetingNotification.html',
-				variables: {
-					member,
-					org,
-					meeting,
-					formattedStart,
-					formattedEnd,
-					renderedDescription: safeDescription
-				}
-			});
-		}
+		await Promise.all(
+			members.map(async member => {
+				await sendEmail({
+					to: member.email,
+					subject: `${org.name} altered a meeting | StuyActivities`,
+					template: 'alterMeetingNotification.html',
+					variables: {
+						member,
+						org,
+						meeting,
+						formattedStart,
+						formattedEnd,
+						renderedDescription: safeDescription
+					}
+				});
+			})
+		);
 	}
 
 	const gEventInfo = {

--- a/src/graphql/resolvers/Mutation/createMeeting.js
+++ b/src/graphql/resolvers/Mutation/createMeeting.js
@@ -196,23 +196,23 @@ export default async (
 		.tz('America/New_York')
 		.format('dddd, MMMM Do YYYY, h:mm a');
 
-	for (let i = 0; i < members.length; i++) {
-		const member = members[i];
-
-		await sendEmail({
-			to: member.email,
-			subject: `${org.name} scheduled a meeting | StuyActivities`,
-			template: 'meetingNotification.html',
-			variables: {
-				member,
-				org,
-				meeting,
-				formattedStart,
-				formattedEnd,
-				renderedDescription: safeDescription
-			}
-		});
-	}
+	await Promise.all(
+		members.map(async member => {
+			await sendEmail({
+				to: member.email,
+				subject: `${org.name} scheduled a meeting | StuyActivities`,
+				template: 'meetingNotification.html',
+				variables: {
+					member,
+					org,
+					meeting,
+					formattedStart,
+					formattedEnd,
+					renderedDescription: safeDescription
+				}
+			});
+		})
+	);
 
 	// Add the meeting to the google calendar
 	let googleCalendar = await googleCalendars.orgIdLoader.load(org.id);


### PR DESCRIPTION
Scheduling meetings for large clubs (~200-300+ members) will lead to NetworkErrors due to the request taking over 1 minute to resolve.
This is because we send out all emails in sequence, rather than in parallel using `Promise.all()`. By leveraging asynchronous functions to their full potential, we can reduce the response time for all clubs by a factor of 1/2 or better.

Here some average request times (in seconds, as measured by Firefox Network Monitor)
| Club | Before Patches | After Patches |
|--------|--------|--------|
| NHD (~35-40 emails) | 9.90 | 2.97-4.05 |
| Red Cross (~358 emails) | > 1min (Timeout 502) | 27-31 | 